### PR TITLE
feat: add Tavily search provider option to search.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 parallel-web>=1.0.0,<2.0.0
 requests>=2.28.0,<3.0.0
+tavily-python>=0.3.0

--- a/scripts/search.py
+++ b/scripts/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Parallel.ai Search API
-Usage: python3 search.py <query> [--max-results N] [--mode one-shot|agentic]
+Parallel.ai / Tavily Search API
+Usage: python3 search.py <query> [--max-results N] [--mode one-shot|agentic] [--provider parallel|tavily]
 """
 
 import os
@@ -12,9 +12,7 @@ import argparse
 from parallel import Parallel
 
 API_KEY = os.environ.get("PARALLEL_API_KEY")
-if not API_KEY:
-    print("Error: PARALLEL_API_KEY environment variable is required", file=sys.stderr)
-    sys.exit(1)
+TAVILY_API_KEY = os.environ.get("TAVILY_API_KEY")
 
 def search(objective: str, max_results: int = 10, mode: str = "one-shot"):
     """Search using Parallel SDK."""
@@ -24,6 +22,37 @@ def search(objective: str, max_results: int = 10, mode: str = "one-shot"):
         max_results=max_results,
         objective=objective
     )
+
+def tavily_search(query: str, max_results: int = 10):
+    """Search using Tavily API."""
+    from tavily import TavilyClient
+    client = TavilyClient(api_key=TAVILY_API_KEY)
+    return client.search(
+        query=query,
+        max_results=max_results,
+        search_depth="advanced",
+    )
+
+def format_tavily_results(response: dict) -> str:
+    """Format Tavily search results for display."""
+    output = []
+    output.append(f"🔍 Tavily Search\n")
+
+    for i, result in enumerate(response.get("results", []), 1):
+        title = result.get("title") or "No title"
+        url = result.get("url", "")
+        content = result.get("content", "")
+        score = result.get("score")
+
+        score_str = f" (score: {score:.2f})" if score is not None else ""
+        output.append(f"**{i}. [{title}]({url})**{score_str}")
+
+        if content:
+            excerpt = content.replace("\n", " ").strip()[:400]
+            output.append(f"   {excerpt}...")
+        output.append("")
+
+    return "\n".join(output)
 
 def format_results(response) -> str:
     """Format search results for display."""
@@ -51,37 +80,60 @@ def format_results(response) -> str:
     return "\n".join(output)
 
 def main():
-    parser = argparse.ArgumentParser(description="Parallel.ai Search")
+    parser = argparse.ArgumentParser(description="Parallel.ai / Tavily Search")
     parser.add_argument("query", nargs="*", help="Search query")
     parser.add_argument("--max-results", "-n", type=int, default=10)
     parser.add_argument("--mode", "-m", default="one-shot", choices=["one-shot", "agentic", "fast"])
+    parser.add_argument("--provider", "-p", default="parallel", choices=["parallel", "tavily"])
     parser.add_argument("--json", "-j", action="store_true", help="Output raw JSON")
-    
+
     args = parser.parse_args()
-    
+
     if not args.query:
         parser.print_help()
         sys.exit(1)
-    
+
     query = " ".join(args.query)
-    response = search(query, max_results=args.max_results, mode=args.mode)
-    
-    if args.json:
-        # Convert to dict for JSON output
-        print(json.dumps({
-            "search_id": response.search_id,
-            "results": [
-                {
-                    "url": r.url,
-                    "title": r.title,
-                    "publish_date": r.publish_date,
-                    "excerpts": r.excerpts
-                }
-                for r in response.results
-            ]
-        }, indent=2))
+
+    if args.provider == "tavily":
+        if not TAVILY_API_KEY:
+            print("Error: TAVILY_API_KEY environment variable is required when --provider=tavily", file=sys.stderr)
+            sys.exit(1)
+        response = tavily_search(query, max_results=args.max_results)
+        if args.json:
+            print(json.dumps({
+                "results": [
+                    {
+                        "url": r.get("url"),
+                        "title": r.get("title"),
+                        "content": r.get("content"),
+                        "score": r.get("score"),
+                    }
+                    for r in response.get("results", [])
+                ]
+            }, indent=2))
+        else:
+            print(format_tavily_results(response))
     else:
-        print(format_results(response))
+        if not API_KEY:
+            print("Error: PARALLEL_API_KEY environment variable is required", file=sys.stderr)
+            sys.exit(1)
+        response = search(query, max_results=args.max_results, mode=args.mode)
+        if args.json:
+            print(json.dumps({
+                "search_id": response.search_id,
+                "results": [
+                    {
+                        "url": r.url,
+                        "title": r.title,
+                        "publish_date": r.publish_date,
+                        "excerpts": r.excerpts
+                    }
+                    for r in response.results
+                ]
+            }, indent=2))
+        else:
+            print(format_results(response))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Added Tavily as a configurable search provider in `scripts/search.py`, selectable via `--provider tavily` flag (default remains `parallel`)
- Implemented `tavily_search()` using `TavilyClient.search()` with advanced search depth
- Added `format_tavily_results()` to normalize Tavily response fields (title, url, content, score) into the existing output format
- Moved API key validation into `main()` so each provider only requires its own key
- The `--mode` flag is Parallel-specific and silently ignored when using Tavily

## Files changed
- `scripts/search.py` — Added `--provider` flag, `tavily_search()`, `format_tavily_results()`, provider routing in `main()`
- `requirements.txt` — Added `tavily-python>=0.3.0`

## Dependency changes
- Added `tavily-python>=0.3.0` to `requirements.txt`

## Environment variable changes
- Added `TAVILY_API_KEY` (optional; required only when `--provider=tavily`)

## Notes for reviewers
- Existing Parallel.ai functionality is fully preserved and remains the default
- Tavily import is deferred inside `tavily_search()` to avoid import errors when tavily-python is not installed and the parallel provider is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration is functionally correct and complete. The additive strategy is properly executed: the Parallel path is fully preserved, the Tavily path is correctly guarded by a per-provider API key check, and the SDK usage (TavilyClient, client.search() with query/max_results/search_depth) matches the official SDK reference. No critical or major issues were found. Four minor issues are noted: an unpinned upper-bound version for tavily-python (inconsistent with other deps), a lazy import for TavilyClient that is stylistically inconsistent with the top-level Parallel import, a superfluous f-string prefix in format_tavily_results(), and no README update to document the new TAVILY_API_KEY variable and --provider flag.
