### PR TITLE
feat: add Tavily extract provider option to scripts/extract.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 parallel-web>=1.0.0,<2.0.0
 requests>=2.28.0,<3.0.0
+tavily-python>=0.3.0

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """
-Parallel.ai Extract API - Clean content extraction from any URL.
+URL content extraction via Parallel.ai or Tavily.
 
 Usage:
   python3 extract.py https://stripe.com/docs/api  # Extract with excerpts
   python3 extract.py https://example.com/paper.pdf --full  # Full content
   python3 extract.py https://sec.gov/10-K.htm --objective "Extract risk factors"
+  python3 extract.py https://example.com --provider tavily  # Use Tavily extract
 """
 
 import os
@@ -16,9 +17,6 @@ import argparse
 from parallel import Parallel
 
 API_KEY = os.environ.get("PARALLEL_API_KEY")
-if not API_KEY:
-    print("Error: PARALLEL_API_KEY environment variable is required", file=sys.stderr)
-    sys.exit(1)
 
 
 def extract(
@@ -40,6 +38,53 @@ def extract(
     
     result = client.beta.extract(**params)
     return result
+
+
+def tavily_extract(urls: list, full_content: bool = False, objective: str = None) -> dict:
+    """Extract content from URLs using Tavily."""
+    tavily_key = os.environ.get("TAVILY_API_KEY")
+    if not tavily_key:
+        print("Error: TAVILY_API_KEY environment variable is required when --provider=tavily", file=sys.stderr)
+        sys.exit(1)
+
+    from tavily import TavilyClient
+
+    client = TavilyClient(api_key=tavily_key)
+
+    params = {"urls": urls[:20]}
+
+    if full_content:
+        params["extract_depth"] = "advanced"
+
+    if objective:
+        params["query"] = objective
+
+    result = client.extract(**params)
+
+    # Normalize into the structure format_result() expects
+    class _Item:
+        def __init__(self, url, raw_content):
+            self.url = url
+            self.title = url
+            self.publish_date = None
+            self.excerpts = None
+            self.content = raw_content
+
+    class _Result:
+        def __init__(self, items, failed):
+            self.extract_id = "tavily"
+            self.results = items
+            self.failed = failed
+
+    items = []
+    for r in result.get("results", []):
+        items.append(_Item(r.get("url", ""), r.get("raw_content", "")))
+
+    failed = result.get("failed_results", [])
+    if failed:
+        print(f"⚠️  {len(failed)} URL(s) failed to extract", file=sys.stderr)
+
+    return _Result(items, failed)
 
 
 def format_result(result) -> str:
@@ -81,26 +126,39 @@ def format_result(result) -> str:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Parallel.ai Extract API")
+    parser = argparse.ArgumentParser(description="URL content extraction via Parallel.ai or Tavily")
     parser.add_argument("urls", nargs="+", help="URLs to extract content from")
+    parser.add_argument("--provider", "-p", choices=["parallel", "tavily"],
+                       default="parallel", help="Extraction provider (default: parallel)")
     parser.add_argument("--objective", "-o", metavar="TEXT",
                        help="Focus extraction on specific content (e.g., 'Extract API endpoints')")
     parser.add_argument("--full", "-f", action="store_true",
                        help="Return full page content instead of excerpts")
     parser.add_argument("--json", "-j", action="store_true",
                        help="Output raw JSON")
-    
+
     args = parser.parse_args()
-    
-    client = Parallel(api_key=API_KEY)
-    
+
     try:
-        result = extract(
-            client,
-            urls=args.urls,
-            objective=args.objective,
-            full_content=args.full,
-        )
+        if args.provider == "tavily":
+            if args.objective:
+                print("⚠️  --objective is passed as query hint for Tavily (no direct equivalent)", file=sys.stderr)
+            result = tavily_extract(
+                urls=args.urls,
+                full_content=args.full,
+                objective=args.objective,
+            )
+        else:
+            if not API_KEY:
+                print("Error: PARALLEL_API_KEY environment variable is required", file=sys.stderr)
+                sys.exit(1)
+            client = Parallel(api_key=API_KEY)
+            result = extract(
+                client,
+                urls=args.urls,
+                objective=args.objective,
+                full_content=args.full,
+            )
         
         if args.json:
             output = {


### PR DESCRIPTION
## Summary
- Added `--provider` flag (`parallel`|`tavily`) to `scripts/extract.py`, defaulting to `parallel`
- Implemented `tavily_extract()` using `TavilyClient.extract()` from `tavily-python`
- Normalized Tavily response (`url`, `raw_content`, `failed_results`) into the existing `format_result()` structure via lightweight adapter classes
- Mapped `--full` to Tavily's `extract_depth="advanced"` and `--objective` to Tavily's `query` parameter
- Added `TAVILY_API_KEY` env var guard (required only when `--provider=tavily`)
- Deferred `PARALLEL_API_KEY` check so it's only required when using the parallel provider
- Added `tavily-python>=0.3.0` to `requirements.txt`

## Files changed
- `scripts/extract.py` — added `--provider` flag, `tavily_extract()` function, provider routing in `main()`
- `requirements.txt` — added `tavily-python>=0.3.0`

## Dependency changes
- Added `tavily-python>=0.3.0` to `requirements.txt`

## Environment variable changes
- Added `TAVILY_API_KEY` (required only when `--provider=tavily`)

## Notes for reviewers
- Existing Parallel.ai code path is untouched; this is a purely additive change
- Tavily extract limits to 20 URLs per call (API constraint)
- `--objective` is passed as Tavily's `query` parameter (closest equivalent) with a stderr warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Automated Review

- Passed after 1 attempt(s)
- Final review: The migration is correct and complete. Tavily SDK usage is valid — `TavilyClient.extract()` is called with the right parameters (`urls`, `extract_depth`, `query`), the 20-URL cap is respected, and the response fields (`results[].url`, `results[].raw_content`, `failed_results`) are parsed correctly per the Tavily extract API contract. The additive approach is well-executed: the Parallel.ai path is fully preserved, the `PARALLEL_API_KEY` guard was correctly moved from module-level into `main()` so it only fires when that provider is selected, and the `TAVILY_API_KEY` guard is similarly scoped. `requirements.txt` was updated with `tavily-python>=0.3.0`. Four minor issues were found but none block approval.
